### PR TITLE
hotfix: Fixed return error in path in payment record

### DIFF
--- a/src/Exceptions/Error.php
+++ b/src/Exceptions/Error.php
@@ -88,6 +88,9 @@ class Error
         $errors = [];
         if (!empty($error_obj->errors)) {
             foreach ($error_obj->errors as $error) {
+                if (!isset($error->path)) {
+                    $error->path = '';
+                }
                 $errors[] = new self($error->code, $error->path, $error->description);
             }
         } elseif (!empty($error_obj->error)) {


### PR DESCRIPTION
When a new payment is made after it has already been added previously, the api was not returning a path in the stdclass assembly. I added a validation in the Error.php class to validate its existence. It could only be added the ternary operator of php 7, however to maintain compatibility with previous versions of the language, we needed to add the if.