### PR TITLE
feat(Payment): adds a method to receive and return the customer device data

### DIFF
--- a/src/Resource/Payment.php
+++ b/src/Resource/Payment.php
@@ -123,6 +123,7 @@ class Payment extends MoipResource
         $this->data = new stdClass();
         $this->data->installmentCount = 1;
         $this->data->fundingInstrument = new stdClass();
+        $this->data->device = new stdClass();
     }
 
     /**
@@ -189,6 +190,7 @@ class Payment extends MoipResource
         $payment->data->amount->currency = $this->getIfSet('currency', $response->amount);
         $payment->data->installmentCount = $this->getIfSet('installmentCount', $response);
         $payment->data->fundingInstrument = $this->getIfSet('fundingInstrument', $response);
+        $payment->data->device = $this->getIfSet('device', $response);
         $payment->data->payments = $this->getIfSet('payments', $response);
         $payment->data->escrows = $this->getIfSet('escrows', $response);
         $payment->data->fees = $this->getIfSet('fees', $response);
@@ -268,6 +270,16 @@ class Payment extends MoipResource
     }
 
     /**
+     * Returns the device fingerprint data.
+     *
+     * @return stdClass
+     */
+    public function getDeviceFingerprint()
+    {
+        return $this->data->device;
+    }
+
+    /**
      * Get href to Boleto
      * *.
      *
@@ -322,6 +334,16 @@ class Payment extends MoipResource
     }
 
     /**
+     * Returns delay capture.
+     *
+     * @return stdClass
+     */
+    public function getDelayCapture()
+    {
+        return $this->data->delayCapture;
+    }
+
+    /**
      * Returns escrow.
      *
      * @return stdClass
@@ -371,6 +393,20 @@ class Payment extends MoipResource
     public function setFundingInstrument(stdClass $fundingInstrument)
     {
         $this->data->fundingInstrument = $fundingInstrument;
+
+        return $this;
+    }
+
+    /**
+     * Set payment device.
+     *
+     * @param \stdClass $device
+     *
+     * @return $this
+     */
+    public function setDevice(stdClass $device)
+    {
+        $this->data->device = $device;
 
         return $this;
     }
@@ -528,6 +564,30 @@ class Payment extends MoipResource
     }
 
     /**
+     * Set device fingerprint
+     * Customer device data used in the payment.
+     *
+     * @param string                  $ip              Customer IP address
+     * @param float                   $latitude        Customer latitude.
+     * @param float                   $longitude       Customer longitude.
+     * @param string                  $userAgent       Device userAgent.
+     * @param string                  $fingerprint     Device fingerprint.
+     *
+     * @return $this
+     */
+    public function setDeviceFingerprint($ip, $latitude, $longitude, $userAgent, $fingerprint)
+    {
+        $this->data->device->geolocation = new stdClass();
+        $this->data->device->geolocation->latitude = $latitude;
+        $this->data->device->geolocation->longitude = $longitude;
+        $this->data->device->ip = $ip;
+        $this->data->device->userAgent = $userAgent;
+        $this->data->device->fingerprint = $fingerprint;
+
+        return $this;
+    }
+
+    /**
      * Set payment means made available by banks.
      *
      * @param string           $bankNumber     Bank number. Possible values: 001, 237, 341, 041.
@@ -583,9 +643,9 @@ class Payment extends MoipResource
      *
      * @return $this
      */
-    public function setDelayCapture()
+    public function setDelayCapture($delayCapture = true)
     {
-        $this->data->delayCapture = true;
+        $this->data->delayCapture = $delayCapture;
 
         return $this;
     }


### PR DESCRIPTION
## History
Our risk analysis department instructs sellers to send the buyer’s device data when creating the payment so that it can be used to ensure greater security in the transactional process and consequently improve the conversion of our customers. Therefore, this PR includes in our SDK developed in PHP, the methods and functions necessary for the salespeople to be able to request and send us such information.

## Description
Creates in the Payment class a method to receive the customer device data (IP address, geolocation, user agent, and the device fingerprint), and a method to retrieve this information.

## Reference
Technical reference about this feature: https://docs.moip.com.br/reference#criar-pagamento

## Tasks
- [x] Creates and put in the initialize method the device structure 
- [x] Creates a method to set and receive the customer device data
- [x] Creates a method that returns the customer device data
- [x] Maps the data return from the customer device and includes this return in the populate method
